### PR TITLE
[Feature] ImageConversion: support for converting TensorImage of Type float32 to TensorBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Adds support to image to buffer conversion of floating point pixel images for those with a need to input floating point pixels values.
-
 # TensorFlow Lite Flutter Helper Library
 
 Makes use of TensorFlow Lite Interpreter on Flutter easier by

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Adds support to image to buffer conversion of floating point pixel images for those with a need to input floating point pixels values.
+
 # TensorFlow Lite Flutter Helper Library
 
 Makes use of TensorFlow Lite Interpreter on Flutter easier by

--- a/lib/src/image/image_conversions.dart
+++ b/lib/src/image/image_conversions.dart
@@ -2,13 +2,15 @@ import 'package:image/image.dart';
 import 'package:tflite_flutter/tflite_flutter.dart';
 import 'package:tflite_flutter_helper/src/image/tensor_image.dart';
 import 'package:tflite_flutter_helper/src/tensorbuffer/tensorbuffer.dart';
+import 'dart:typed_data';
 
 /// Implements some stateless image conversion methods.
 ///
 /// This class is an internal helper.
 class ImageConversion {
   static Image convertTensorBufferToImage(TensorBuffer buffer, Image image) {
-    if (buffer.getDataType() != TfLiteType.uint8) {
+    if (buffer.getDataType() != TfLiteType.uint8 &&
+        buffer.getDataType() != TfLiteType.float32) {
       throw UnsupportedError(
         "Converting TensorBuffer of type ${buffer.getDataType()} to Image is not supported yet.",
       );
@@ -26,6 +28,18 @@ class ImageConversion {
       );
     }
 
+    switch (buffer.getDataType()) {
+      case TfLiteType.uint8:
+        return int8BufferToImage(buffer, w, h, image);
+      case TfLiteType.float32:
+        return float32BufferToImage(buffer, w, h, image);
+      default:
+        return image;
+    }
+  }
+
+  static Image int8BufferToImage(
+      TensorBuffer buffer, int w, int h, Image image) {
     List<int> rgbValues = buffer.getIntList();
 
     assert(rgbValues.length == w * h * 3);
@@ -45,22 +59,58 @@ class ImageConversion {
     return image;
   }
 
+  static Image float32BufferToImage(
+      TensorBuffer buffer, int w, int h, Image image) {
+    List<double> rgbValues = buffer.getDoubleList();
+
+    assert(rgbValues.length == w * h * 3);
+
+    for (int i = 0, j = 0, wi = 0, hi = 0; j < rgbValues.length; i++) {
+      int r = ((rgbValues[j++] + 1) * 127.5).floor();
+      int g = ((rgbValues[j++] + 1) * 127.5).floor();
+      int b = ((rgbValues[j++] + 1) * 127.5).floor();
+      image.setPixelRgba(wi, hi, r, g, b);
+      wi++;
+      if (wi % w == 0) {
+        wi = 0;
+        hi++;
+      }
+    }
+    return image;
+  }
+
   static void convertImageToTensorBuffer(Image image, TensorBuffer buffer) {
     int w = image.width;
     int h = image.height;
     List<int> intValues = image.data;
-
     List<int> shape = [h, w, 3];
-    List<int> rgbValues = List(h * w * 3);
-    for (int i = 0, j = 0; i < intValues.length; i++) {
-      if (intValues[i] == null) {
-        print(i);
+    if (buffer.getDataType() == TfLiteType.uint8) {
+      List<int> rgbValues = List(h * w * 3);
+      for (int i = 0, j = 0; i < intValues.length; i++) {
+        if (intValues[i] == null) {
+          print(i);
+        }
+        rgbValues[j++] = ((intValues[i]) & 0xFF);
+        rgbValues[j++] = ((intValues[i] >> 8) & 0xFF);
+        rgbValues[j++] = ((intValues[i] >> 16) & 0xFF);
       }
-      rgbValues[j++] = ((intValues[i]) & 0xFF);
-      rgbValues[j++] = ((intValues[i] >> 8) & 0xFF);
-      rgbValues[j++] = ((intValues[i] >> 16) & 0xFF);
-    }
 
-    buffer.loadList(rgbValues, shape: shape);
+      buffer.loadList(rgbValues, shape: shape);
+    } else if (buffer.getDataType() == TfLiteType.float32) {
+      Float32List rgbValues = new Float32List(w * h * 3);
+      for (int i = 0, j = 0; i < intValues.length; i++) {
+        if (intValues[i] == null) {
+          print(i);
+        }
+        rgbValues[j++] = (((intValues[i]) & 0xFF) / 255.0).toDouble();
+        rgbValues[j++] = (((intValues[i] >> 8) & 0xFF) / 255.0).toDouble();
+        rgbValues[j++] = (((intValues[i] >> 16) & 0xFF) / 255.0).toDouble();
+      }
+      buffer.loadList(rgbValues, shape: shape);
+    } else {
+      throw UnsupportedError(
+        "The TensorBuffer of type ${buffer.getBuffer()} to Image is not supported yet.",
+      );
+    }
   }
 }


### PR DESCRIPTION
This allows for the inputting of floating point rgb pixel values for models that need the pixels as such. Yolov4 models converted to tflite use floating point values.